### PR TITLE
Replace use of deprecated base64.(en|de)codestring with (en|de)codebytes

### DIFF
--- a/pysphere/ZSI/auth.py
+++ b/pysphere/ZSI/auth.py
@@ -7,7 +7,7 @@ from pysphere.ZSI import *
 from pysphere.ZSI import _copyright
 import base64, os
 
-_b64_decode = base64.decodestring
+_b64_decode = base64.decodebytes
 
 # Typecode to parse a ZSI BasicAuth header.
 _auth_tc = TC.Struct(None,

--- a/pysphere/ZSI/client.py
+++ b/pysphere/ZSI/client.py
@@ -15,7 +15,7 @@ import base64, http.client, http.cookies, types, time, urllib.parse
 from pysphere.ZSI.address import Address
 from pysphere.ZSI.wstools.logging import getLogger as _GetLogger
 import collections
-_b64_encode = base64.encodestring
+_b64_encode = base64.encodebytes
 
 class _AuthHeader:
     """<BasicAuth xmlns="ZSI_SCHEMA_URI">

--- a/pysphere/ZSI/resolvers.py
+++ b/pysphere/ZSI/resolvers.py
@@ -5,7 +5,7 @@
 
 from pysphere.ZSI import _copyright, _child_elements, EvaluateException, TC, UNICODE_ENCODING
 import urllib.request, urllib.parse, urllib.error
-from base64 import decodestring as b64decode
+from base64 import decodebytes as b64decode
 import email
 import io
 

--- a/pysphere/ZSI/twisted/WSsecurity.py
+++ b/pysphere/ZSI/twisted/WSsecurity.py
@@ -191,7 +191,7 @@ class WSSecurityHandler:
                     if i is None: continue
                     digest.update(i)
 
-                if password == base64.encodestring(digest.digest()).strip():
+                if password == base64.encodebytes(digest.digest()).strip():
                     return ps
                 
                 raise RuntimeError('Unauthorized, digest failed')
@@ -256,7 +256,7 @@ class WSSecurityHandler:
             except IndexError:
                 raise RuntimeError('unknown digestMethods Algorithm')
             
-            digestValue = base64.encodestring(digest(xml).digest()).strip()
+            digestValue = base64.encodebytes(digest(xml).digest()).strip()
             if si.Reference.DigestValue != digestValue:
                 raise RuntimeError('digest does not match')
             


### PR DESCRIPTION
Fixes an error when running with python3.9 - see https://bugs.python.org/issue39351
base64.encodestring and base64.decodestring have been deprecated since 3.1 and replaced with encodebytes/decodebytes